### PR TITLE
Dockerfile: Change the /etc destination to /etc/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY containersetup.sh \
             toaster-launch.sh \
             toaster-entry.py \
         /usr/bin/
-COPY sudoers.usersetup /etc
+COPY sudoers.usersetup /etc/
 
 # We remove the user because we add a new one of our own.
 # The usersetup user is solely for adding a new user that has the same uid,


### PR DESCRIPTION
Evidently /etc does not work with some versions of docker, so be
explicit.

Signed-off-by: Randy Witt randy.e.witt@linux.intel.com
