### PR TITLE
Added a new option (--local) when the contianer is run. If we run the

### DIFF
--- a/toaster-entry.py
+++ b/toaster-entry.py
@@ -27,10 +27,16 @@ parser = argparse.ArgumentParser(epilog="NOTE: The --workdir is the path as "
 
 parser.add_argument("--workdir", default='/workdir',
                     help="Directory to use for the toasterbuild")
+parser.add_argument("--local", action="store_true",
+                    help="Run Toaster from the poky in the workdir instead of the default one in the container."
+                    "This option is intended for developers of Toaster itself and is not supported for end users.")
 
 args = parser.parse_args()
 
 cmd = ("usersetup.py --username=toasteruser --workdir={} "
        "toaster-launch.sh {}")
 cmd = cmd.format(args.workdir, args.workdir).split()
+
+if args.local:
+    cmd.append("LOCAL")
 os.execvp(cmd[0], cmd)

--- a/toaster-launch.sh
+++ b/toaster-launch.sh
@@ -14,6 +14,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 workdir="${1}"
+LOCAL="${2}"
 
 # If it doesn't already exist copy the toaster database from the container
 # so that it doesn't have to be created again
@@ -21,8 +22,21 @@ bootstrap="/home/usersetup"
 builddir="${workdir}/build"
 toasterdb="${builddir}/toaster.sqlite"
 
+if  [ "${LOCAL}x" != "x" ]; then
+    if [ ! -e ${workdir}/poky ]; then
+	echo "The LOCAL mode assumes that there is a useable poky in the workdir you passed in."
+	echo "Current container view of workdir is ${workdir}"
+	exit 1
+    fi
+    # in local mode we reset bootstrap to be workdir and just run what's there
+    bootstrap=${workdir}
+fi
+
+
+
 mkdir -p ${builddir}
-if [ ! -e "${toasterdb}" ]; then
+# don't copy over the database if it's already there or if we are in local mode
+if [ ! -e "${toasterdb}" ] && [ "${LOCAL}x" = "x" ] ; then
     cp ${bootstrap}/toaster.sqlite ${toasterdb}
 
     # Replace /home/usersetup with the new workdir


### PR DESCRIPTION
container with --local then whatever poky is in our workdir is used.
This is intended for use by Toaster developers, not end users. If
there is no poky in the workdir, the container prints an error and
exits.

Signed-off-by: bavery brian.avery@intel.com
