### PR TITLE
sudoers.usersetup: keep env variables passed to docker run

### DIFF
--- a/sudoers.usersetup
+++ b/sudoers.usersetup
@@ -1,3 +1,3 @@
 usersetup ALL=NOPASSWD: /usr/bin/restrict_groupadd.sh
 usersetup ALL=NOPASSWD: /usr/bin/restrict_useradd.sh
-usersetup ALL = (toasteruser) NOPASSWD: /usr/bin/toaster-launch.sh
+usersetup ALL = (toasteruser) NOPASSWD:SETENV: /usr/bin/toaster-launch.sh


### PR DESCRIPTION
Environment variables passed to docker run via -e such as -e
"http_proxy=myproxy.com:8080" should be available to the user running
toaster.  This adds SETENV to the sudoers.usersetup file so that
usersetup.py has the right to call sudo with a --preserve-env flag.
This is to keep in sync with the usersetup.py which comes from the
extensible sdk container.

Signed-off-by: bavery brian.avery@intel.com
