### PR TITLE
.travis.yml: Add a morty build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     # BRANCH is the actual branch/tag in the github repo
     # DOCKERHUB_TAGS are the tags to use for the REPO when pushing to dockerhub
     # POKYBRANCH is the branch of poky used during testing.
+    - REPO=crops/toaster-morty BRANCH=morty DOCKERHUB_TAG="latest" POKYBRANCH=morty
     - REPO=crops/toaster-krogoth BRANCH=krogoth DOCKERHUB_TAG="latest" POKYBRANCH=krogoth
     - REPO=crops/toaster-krogoth BRANCH=yocto-2.1 DOCKERHUB_TAG="2.1" POKYBRANCH=krogoth
     - REPO=crops/toaster-master BRANCH=master DOCKERHUB_TAG="latest" POKYBRANCH=master


### PR DESCRIPTION
Although not yet released, the morty branch does build and can be added
in preparation of the release.

Signed-off-by: Randy Witt randy.e.witt@linux.intel.com
