### PR TITLE
runtests.sh - Allow the vnc server to be accessed from off host

### DIFF
--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -142,7 +142,7 @@ function start_selenium() {
 
     printf "\n\nStarting selenium...\n"
     if [ "$VNCPORT" != "" ]; then
-        docker run --rm=true -p 127.0.0.1:$VNCPORT:5900 \
+        docker run --rm=true -p $VNCPORT:5900 \
                    -p 127.0.0.1:4444:4444 --name=$seleniumname \
                    --link=$toastername \
                    selenium/standalone-firefox-debug:$selenium_version \


### PR DESCRIPTION
Sometimes the machine running the test is headless so in order
to see the tests run we need to be able to access the vnc server
from another host. This removes the requirement that the vnc
server be bound to 127.0.0.1. If you set VNCPORT=5900 it will
be bound to 0.0.0.0 and be accessible off host. If you set it
to VNCPORT=127.0.0.1:5900, it will be confined to localhost
access only.

Signed-off-by: brian avery <brian.avery@intel.com>