### PR TITLE
runtests.sh - Allow the vnc server to be accessed from off host

### DIFF
--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -34,10 +34,13 @@
 #    By default it is "master".
 #
 # VNCPORT
-#    When set, the selenium container will be ran with a vncserver listening
+#    When set, the selenium container will be run with a vncserver listening
 #    on this port. The password for the selenium vnc server is "secret". Note,
-#    you cannot of course connect to the vnc server until the selenium
-#    container has finished starting.
+#    you cannot, of course, connect to the vnc server until the selenium
+#    container has finished starting. If you would like to be able to access the
+#    vnc server from a different host, explicitly bind to 0.0.0.0:<portnum>
+#    e.g. VNCPORT=0.0.0.0:6900 and then you can connect to the server from a
+#    different host as "xtightvnc headless.mycomp.com:6900"
 #
 # SHOW_LOGS_ON_FAILURE
 #    When set, if the tests fail, the contents of toaster.log and selenium.log
@@ -89,11 +92,11 @@ function fail () {
          fi
          printf "******************toaster_ui.log*******************\n\n"
 
-	 printf "******************selenium.log******************\n"
+         printf "******************selenium.log******************\n"
          if [ "" != "$seleniumlog" ]; then
              cat $seleniumlog
          fi
-	 printf "******************selenium.log******************\n\n"
+         printf "******************selenium.log******************\n\n"
 
          printf "******************screenshot.hex******************\n"
          printf "*************Run 'xxd -r' to reverse**************\n"
@@ -125,7 +128,7 @@ function start_toaster() {
     while ! grep "$sentinel" $toasterlog >& /dev/null; do
         # Check if the job exited
         if [ "$(ps -p $toasterpid -o comm=)" != "docker" ] ; then
-    	    echo "ERROR: The toaster job couldn't be found."
+            echo "ERROR: The toaster job couldn't be found."
             fail
         fi
         sleep 1
@@ -142,7 +145,12 @@ function start_selenium() {
 
     printf "\n\nStarting selenium...\n"
     if [ "$VNCPORT" != "" ]; then
-        docker run --rm=true -p 127.0.0.1:$VNCPORT:5900 \
+        # default to loclahost visibility only, unless specified.
+        HOST_VNCBINDING="127.0.0.1:$VNCPORT"
+        if   echo $VNCPORT | grep -q ":"; then
+            HOST_VNCBINDING="$VNCPORT"
+        fi
+        docker run --rm=true -p $HOST_VNCBINDING:5900 \
                    -p 127.0.0.1:4444:4444 --name=$seleniumname \
                    --link=$toastername \
                    selenium/standalone-firefox-debug:$selenium_version \
@@ -158,7 +166,7 @@ function start_selenium() {
     while ! grep "$sentinel" $seleniumlog >& /dev/null; do
         # Check if the job exited
         if [ "$(ps -p $seleniumpid -o comm=)" != "docker" ] ; then
-    	    echo "ERROR: The selenium job couldn't be found."
+            echo "ERROR: The selenium job couldn't be found."
             fail
         fi
         sleep 1
@@ -241,7 +249,7 @@ if [ "" == "$POKYDIR" ]; then
     echo "no migration priming PASSED"
 
     if grep -q "INFO Fetching layers" $toasterlog; then
-	fail
+        fail
     fi
     echo "layerindex priming PASSED"
 fi


### PR DESCRIPTION
Sometimes the machine running the test is headless so in order
to see the tests run we need to be able to access the vnc server
from another host. If you set VNCPORT=5900 it will be bound to
127.0.0.1:5900 and will be accessible on localhost only.  If you
set VNCPORT=0.0.0.0:5900 it will be bound to 0.0.0.0 and be
accessible off host.

Signed-off-by: brian avery <brian.avery@intel.com>