### PR TITLE
primetoaster.sh,toaster-launch.sh: sqlite moved

### DIFF
--- a/primetoaster.sh
+++ b/primetoaster.sh
@@ -33,6 +33,14 @@ cd $WORKDIR
 . $POKYDIR/bitbake/bin/toaster start
 
 . $POKYDIR/bitbake/bin/toaster stop
-
-mv toaster.sqlite $WORKDIR || exit 1
+T_DB_FILE="toaster.sqlite"
+T_DB=`find $HOME -iname $T_DB_FILE`
+if [ $(dirname $T_DB) != $(readlink -f  $WORKDIR) ]; then
+    echo "Moving $T_DB/$T_DB_FILE to $WORKDIR"
+    mv ${T_DB} $WORKDIR || exit 1
+fi
+if [ ! -f $WORKDIR/$T_DB_FILE ]; then
+    echo "$WORKDIR/$T_DB_FILE not found, erroring"
+    exit 1
+fi
 rm $WORKDIR/build -rf || exit 1

--- a/toaster-launch.sh
+++ b/toaster-launch.sh
@@ -20,7 +20,12 @@ uselocal="${2}"
 # so that it doesn't have to be created again
 bootstrap="/home/usersetup"
 builddir="${workdir}/build"
-toasterdb="${builddir}/toaster.sqlite"
+# toaster moved the toaster.sqlite db from $builddir to $toaster_dir after morty
+if grep TOASTER_DIR $bootstrap/poky/bitbake/bin/toaster | grep -q pwd; then
+    toasterdb="${builddir}/toaster.sqlite"
+else
+    toasterdb="${workdir}/toaster.sqlite"
+fi
 
 if  [ "${uselocal}" = "LOCAL" ]; then
     if [ ! -e ${workdir}/poky ]; then


### PR DESCRIPTION
Toaster moved the location of toaster.sqlite from the
BUILDDIR to the BUILDDIR/.. after morty.  This patchset
deals with that move for both priming and launching.

Signed-off-by: brian avery <brian.avery@intel.com>