### PR TITLE
Timo/fix build and update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,9 @@ env:
     # BRANCH is the actual branch/tag in the github repo
     # DOCKERHUB_TAGS are the tags to use for the REPO when pushing to dockerhub
     # POKYBRANCH is the branch of poky selected by toaster to use during tests.
-    - REPO=crops/toaster-morty BRANCH=morty DOCKERHUB_TAG="latest" POKYBRANCH=morty
-    - REPO=crops/toaster-krogoth BRANCH=krogoth DOCKERHUB_TAG="latest" POKYBRANCH=krogoth
-    - REPO=crops/toaster-krogoth BRANCH=yocto-2.1 DOCKERHUB_TAG="2.1" POKYBRANCH=krogoth
-    - REPO=crops/toaster-krogoth BRANCH=yocto-2.1.1 DOCKERHUB_TAG="2.1.1" POKYBRANCH=krogoth
-    - REPO=crops/toaster-krogoth BRANCH=yocto-2.1.2 DOCKERHUB_TAG="2.1.2" POKYBRANCH=krogoth
+    - REPO=crops/toaster-dunfell BRANCH=dunfell DOCKERHUB_TAG="latest" POKYBRANCH=dunfell
+    - REPO=crops/toaster-zeus BRANCH=zeus DOCKERHUB_TAG="latest" POKYBRANCH=zeus
+    - REPO=crops/toaster-warrior BRANCH=warrior DOCKERHUB_TAG="latest" POKYBRANCH=warrior
     - REPO=crops/toaster-master BRANCH=master DOCKERHUB_TAG="latest" POKYBRANCH=master
 
   global:
@@ -41,7 +39,7 @@ script:
 notifications:
   email:
     recipients:
-      - brian.avery@intel.com
+      - timothy.t.orling@intel.com
       - david.reyna@windriver.com
       - randy.e.witt@intel.com
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ notifications:
   email:
     recipients:
       - timothy.t.orling@intel.com
+      - ticotimo@gmail.com
       - david.reyna@windriver.com
       - randy.e.witt@intel.com
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Ubuntu 18.04
+dist: bionic
+
 # The language is set to python to ensure virtualenv and python exist for the
 # tests.
 language: python
@@ -23,7 +26,7 @@ env:
     # LATEST_RELEASE_REPO is the dockerhub repo that FLOATING_REPO should
     #                     match
     - FLOATING_REPO=crops/toaster
-    - LATEST_RELEASE_REPO=crops/toaster-morty
+    - LATEST_RELEASE_REPO=crops/toaster-dunfell
     - GITREPO=git://git.yoctoproject.org/poky
 
 before_install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-FROM crops/yocto:ubuntu-16.04-base
+FROM crops/yocto:ubuntu-18.04-base
 
 USER root
 
@@ -28,11 +28,18 @@ COPY primetoaster.sh \
         /usr/bin/
 COPY sudoers.usersetup /etc/
 
+# https://serverfault.com/questions/949991/how-to-install-tzdata-on-a-ubuntu-docker-image
+# For ubuntu, do not use dash.
+RUN which dash &> /dev/null && (\
+    echo "dash dash/sh boolean false" | debconf-set-selections && \
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash) || \
+    echo "Skipping dash reconfigure (not applicable)"
+
 # We remove the user because we add a new one of our own.
 # The usersetup user is solely for adding a new user that has the same uid,
 # as the workspace. 70 is an arbitrary *low* unused uid on debian.
-RUN apt-get -y update && \
-    apt-get -y install python-pip python3-pip sudo sqlite tzdata && \
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
+    apt-get -y install python3-pip sudo sqlite tzdata && \
     apt-get clean && \
     userdel -r yoctouser && \
     groupadd -g 70 usersetup && \
@@ -50,17 +57,7 @@ RUN apt-get -y update && \
 ARG BRANCH
 ARG GITREPO
 RUN git clone $GITREPO --depth=1 --branch=$BRANCH /home/usersetup/poky && \
-
-######### START OF WORKAROUND. DELETE WHEN FIXED IN TOASTER ##########
-######### Workaround needed for the following releases:     #########
-######### 2.1,2.1.1,2.1.2,2.2,2.2.1                         #########
-# This prevents Django 1.8.16's restrictive default on ALLOWED_HOSTS#
-# to break Toaster.  Releases other than those above override the   #
-# ALLOWED_HOSTS to keep the older default behavior. See             #
-# bitbake/lib/toaster/toastermain/settings.py for more information  #
-    pipinstall.sh /home/usersetup/poky/bitbake && \
-    pip uninstall -y django && pip install django==1.8.15
-######### END OF WORKAROUND ##########
+    pipinstall.sh /home/usersetup/poky/bitbake
 
 USER usersetup
 ENV LANG=en_US.UTF-8

--- a/pipinstall.sh
+++ b/pipinstall.sh
@@ -29,7 +29,7 @@ BITBAKEDIR=$1
 
 if grep '#!/usr/bin/env python3' $BITBAKEDIR/bin/bitbake >& /dev/null; then
     pip3 install --upgrade pip && \
-    pip3 install -r $BITBAKEDIR/toaster-requirements.txt
+    /usr/local/bin/pip3 install -r $BITBAKEDIR/toaster-requirements.txt
 else
     pip install --upgrade pip && \
     pip install -r $BITBAKEDIR/toaster-requirements.txt

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -236,7 +236,7 @@ fi
 SCRIPT_DIR=$(dirname "$THIS_SCRIPT")
 SCRIPT_DIR=$(readlink -f "$SCRIPT_DIR")
 
-${SCRIPT_DIR}/smoketests.py --toaster_url="$toastername:8000" \
+${SCRIPT_DIR}/smoketests.py --toaster_url="http://$toastername:8000/" \
                 $timeout_arg \
                 $pokybranch_arg
 echo "smoketests PASSED!"

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -2,7 +2,7 @@
 
 # runtests.sh
 #
-# Copyright (C) 2016 Intel Corporation
+# Copyright (C) 2016-2020 Intel Corporation
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -21,7 +21,7 @@
 # SELENIUM_VERSION
 #    This is the version of selenium that will be used for the selenium
 #    container and the selenium modules installed in the virtualenv. The
-#    default is 2.53.0.
+#    default is 3.141.0.
 #
 # IMAGE
 #    This is the image to be used for toaster. It should be in the same format
@@ -30,7 +30,7 @@
 #
 # POKYBRANCH
 #    If set, this is the branch of poky that will be used by toaster when doing
-#    a build. i.e. "jethro", "krogoth", "master"
+#    a build. i.e. "zeus", "dunfell", "master"
 #    By default it is "master".
 #
 # VNCPORT
@@ -190,7 +190,7 @@ fi
 if [ "" != "$SELENIUM_VERSION" ]; then
     selenium_version="$SELENIUM_VERSION"
 else
-    selenium_version=2.53.0
+    selenium_version=3.141.0
 fi
 
 if [ "" != "$POKYBRANCH" ]; then

--- a/tests/smoketests.py
+++ b/tests/smoketests.py
@@ -85,8 +85,9 @@ parser.add_argument("--timeout", type=int, default="120",
                     help="timeout in seconds to wait for page elements")
 
 args = parser.parse_args()
-driver = webdriver.Remote(args.server_url,
-                          webdriver.DesiredCapabilities.FIREFOX.copy())
+firefox_options = webdriver.FirefoxOptions()
+driver = webdriver.Remote(command_executor=args.server_url,
+                          options=firefox_options)
 
 driver.get(args.toaster_url)
 

--- a/toaster-launch.sh
+++ b/toaster-launch.sh
@@ -53,16 +53,9 @@ fi
 # oe environment setup
 . ${bootstrap}/poky/oe-init-build-env ${builddir}
 
-# run toaster and drop to an interactive shell. On previous versions no
-# arguments webport only took a port. But on more recent versions
-# it also requires an address.
-# Ideally we would ask which was supported, but --help doesn't work on older
-# versions. So "cheat" and grep the toaster script for the usage pattern.
-# Also note if the server listens on localhost in the container, it evidently
+# Run toaster and drop to an interactive shell.
+# Note if the server listens on localhost in the container, it evidently
 # can't be reached even with iptables without "route_localnet" enabled.
-if grep -q "Usage:.*\[webport=<address" ${bootstrap}/poky/bitbake/bin/toaster; then
-    . ${bootstrap}/poky/bitbake/bin/toaster start webport="0.0.0.0:8000"
-else
-    . ${bootstrap}/poky/bitbake/bin/toaster start
-fi
+. ${bootstrap}/poky/bitbake/bin/toaster start webport="0.0.0.0:8000"
+
 bash -i


### PR DESCRIPTION
Warrior, Zeus and Dunfell branches all pass all tests. (Actually, all branches from morty, pyro, rocko, sumo, thud pass, but are not enabled).

There is some kind of hang/failure on current "master", but it is worth bringing the toaster-container back to life while we troubleshoot what is happening on "master".