### PR TITLE
workflows,deploy: reinstate FLOATING_REPO

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -43,13 +43,13 @@ jobs:
           dockerhub_tag: latest
           pokybranch: master
     env:
-      # FLOATING_REPO is the dockerhub repo the can change what it's tracking
-      #               currently it's morty, but on the next release it will
+      # FLOATING_REPO is the dockerhub repo that can change what it's tracking
+      #               currently it's kirkstone, but on the next release it will
       #               match the new release
       # LATEST_RELEASE_REPO is the dockerhub repo that FLOATING_REPO should
       #                     match
       FLOATING_REPO: crops/toaster
-      LATEST_RELEASE_REPO: crops/toaster-honister
+      LATEST_RELEASE_REPO: crops/toaster-kirkstone
       REPO: ${{ matrix.repo }}
       BRANCH: ${{ matrix.branch }}
       DOCKERHUB_TAG: ${{ matrix.dockerhub_tag }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,8 +10,30 @@ set -e
 # Don't deploy on pull requests because it could just be junk code that won't
 # get merged
 if ([ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] || [ "${GITHUB_EVENT_NAME}" = "schedule" ]) && [ "${GITHUB_REF}" = "refs/heads/master" ]; then
+
+    REPOS="${REPO}"
+
+    # If this is the LATEST_RELEASE_REPO we also need to push to the
+    # FLOATING_REPO
+    if [ "${LATEST_RELEASE_REPO}" = "${REPO}" ]; then
+        REPOS="${REPOS} ${FLOATING_REPO}"
+    fi
+
     echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-    docker push ${REPO}:latest
+
+    for repo in $REPOS; do
+        docker tag local $repo:${DOCKERHUB_TAG}
+
+        # Also add a timestamp tag with the committish so that we know when it
+        # was built and what it contains
+        docker tag local $repo:${DOCKERHUB_TAG}-$(date -u +%Y%m%d%H%M)-$(getrev)
+
+        docker push $repo
+    done
+
+    # Show the images so we know what should have been pushed
+    docker images
+
 else
     echo "Not pushing since build was triggered by a pull request."
 fi


### PR DESCRIPTION
In the Travis CI workflow, we used to track the "LATEST_RELEASE_REPO" as
the latest stable release and that was pushed as the crops/toaster
"FLOATING_REPO".

With the recent release of 'kirkstone', set the LATEST_RELEASE_REPO to
match.

While we are at it, reinstate the date-commitish tags that were also
part of the Travis CI workflow.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>