### PR TITLE
deploy: fix tagging

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -22,11 +22,11 @@ if ([ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_
     echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
 
     for repo in $REPOS; do
-        docker tag local $repo:${DOCKERHUB_TAG}
+        docker tag ${REPO} $repo:${DOCKERHUB_TAG}
 
         # Also add a timestamp tag with the committish so that we know when it
         # was built and what it contains
-        docker tag local $repo:${DOCKERHUB_TAG}-$(date -u +%Y%m%d%H%M)-$(getrev)
+        docker tag ${REPO} $repo:${DOCKERHUB_TAG}-$(date -u +%Y%m%d%H%M)-$(getrev)
 
         docker push $repo
     done


### PR DESCRIPTION
The old "docker tag local ..." from the Travis CI workflow no longer
works. Use ${REPO} instead, since we are already tagging the build with
it.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>