### PR TITLE
Dockerfile: fix poky git owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,14 +53,14 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
         /usr/bin/restrict_useradd.sh && \
     echo "#include /etc/sudoers.usersetup" >> /etc/sudoers
 
+USER usersetup
+ENV LANG=en_US.UTF-8
 # Install the toaster requirements.
 ARG BRANCH
 ARG GITREPO
 RUN git clone $GITREPO --depth=1 --branch=$BRANCH /home/usersetup/poky && \
     pipinstall.sh /home/usersetup/poky/bitbake
 
-USER usersetup
-ENV LANG=en_US.UTF-8
 RUN primetoaster.sh /home/usersetup /home/usersetup/poky
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/bin/toaster-entry.py"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ set -e
 
 function getrev {
     docker run -it --rm=true --entrypoint=git -w /home/usersetup/poky \
-        local:latest --no-pager log --pretty=%h -1 | tr -d '\r'
+        ${REPO}:latest --no-pager log --pretty=%h -1 | tr -d '\r'
 }
 
 # Don't deploy on pull requests because it could just be junk code that won't


### PR DESCRIPTION
Latest git complains if the owner of the working tree is not the user.

Also fix the usage in the deploy.sh getrev() function, as it needs to be
using ${REPO} instead of 'local'.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>