### PR TITLE
pipinstall.sh: fix local pip

### DIFF
--- a/pipinstall.sh
+++ b/pipinstall.sh
@@ -1,18 +1,9 @@
 #!/bin/bash
 # Copyright (C) 2016 Intel Corporation
+# Copyright (C) 2022 Konsulko Group
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation.
+# SPDX-License-Identifier: GPL-2.0-only
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 # The sole purpose of this script is to only install the python3 version of
 # the requirements if necessary. Unconditionally trying to install using
@@ -29,7 +20,8 @@ BITBAKEDIR=$1
 
 if grep '#!/usr/bin/env python3' $BITBAKEDIR/bin/bitbake >& /dev/null; then
     pip3 install --upgrade pip && \
-    /usr/local/bin/pip3 install -r $BITBAKEDIR/toaster-requirements.txt
+    export PATH="${PATH}:/home/usersetup/.local/bin" && \
+    /home/usersetup/.local/bin/pip3 install -r $BITBAKEDIR/toaster-requirements.txt
 else
     pip install --upgrade pip && \
     pip install -r $BITBAKEDIR/toaster-requirements.txt


### PR DESCRIPTION
Since we now call this as the usersetup user rather than root, we need
to use the ${HOME}/.local/bin/pip path.

Replace license header with SPDX-License-Identifier

Signed-off-by: Tim Orling <tim.orling@konsulko.com>