### PR TITLE
pipinstall.sh: use ${HOME}/.local/bin

### DIFF
--- a/pipinstall.sh
+++ b/pipinstall.sh
@@ -28,8 +28,8 @@ BITBAKEDIR=$1
 
 
 if grep '#!/usr/bin/env python3' $BITBAKEDIR/bin/bitbake >& /dev/null; then
-    pip3 install --upgrade pip && \
-    /usr/local/bin/pip3 install -r $BITBAKEDIR/toaster-requirements.txt
+    pip3 install --upgrade pip --verbose && \
+    ${HOME}/.local/bin/pip3 install -r $BITBAKEDIR/toaster-requirements.txt
 else
     pip install --upgrade pip && \
     pip install -r $BITBAKEDIR/toaster-requirements.txt


### PR DESCRIPTION
The pip3 upgrade is installed in ${HOME}/.local/bin/

Signed-off-by: Tim Orling <tim.orling@konsulko.com>