### PR TITLE
github/workflows: use setup-python v4

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 


### PR DESCRIPTION
Latest is setup-python@v4
https://github.com/marketplace/actions/setup-python?version=v4.5.0

Fix:

Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-python@v2

Signed-off-by: Tim Orling <tim.orling@konsulko.com>