### PR TITLE
Dockerfile: Use Ubuntu 20.04 base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-FROM crops/yocto:ubuntu-18.04-base
+FROM crops/yocto:ubuntu-20.04-base
 
 USER root
 


### PR DESCRIPTION
Ubuntu 18.04 moves to Extended Security Maintenance (ESM) in April 2023. Ubuntu 20.04 has Hardware and maintenance updates until April 2024.

https://ubuntu.com/about/release-cycle