### PR TITLE
workflows: drop langdale; add mickledore

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -30,10 +30,10 @@ jobs:
           branch: kirkstone
           dockerhub_tag: latest
           pokybranch: kirkstone
-        - repo: crops/toaster-langdale
-          branch: langdale
+        - repo: crops/toaster-mickledore
+          branch: mickledore
           dockerhub_tag: latest
-          pokybranch: langdale
+          pokybranch: mickledore
         - repo: crops/toaster-master
           branch: master
           dockerhub_tag: latest


### PR DESCRIPTION
langdale went EOL with 4.1.4 (May 2023)

mickledore is the current stable release:
Support for 7 months (until November 2023)

nanbield is not yet released.