### PR TITLE
Add scarthgap (5.0); drop EOL dunfell and mickledore

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -22,18 +22,14 @@ jobs:
         # BRANCH is the actual branch/tag in the github repo
         # DOCKERHUB_TAGs are the tags to use for the REPO when pushing to dockerhub
         # POKYBRANCH is the branch of poky selected by toaster to use during tests.
-        - repo: crops/toaster-dunfell
-          branch: dunfell
-          dockerhub_tag: latest
-          pokybranch: dunfell
         - repo: crops/toaster-kirkstone
           branch: kirkstone
           dockerhub_tag: latest
           pokybranch: kirkstone
-        - repo: crops/toaster-mickledore
-          branch: mickledore
+        - repo: crops/toaster-scarthgap
+          branch: scarthgap
           dockerhub_tag: latest
-          pokybranch: mickledore
+          pokybranch: scarthgap
         - repo: crops/toaster-master
           branch: master
           dockerhub_tag: latest

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 


### PR DESCRIPTION
Scarthgap 5.0 Long Term Support (until April 2028)

https://wiki.yoctoproject.org/wiki/Releases
https://docs.yoctoproject.org/next/migration-guides/release-5.0.html https://docs.yoctoproject.org/next/migration-guides/release-notes-5.0.html